### PR TITLE
missing declarations

### DIFF
--- a/src/curves.h
+++ b/src/curves.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 class Curves {
 public:

--- a/src/hyperSMURF.h
+++ b/src/hyperSMURF.h
@@ -62,6 +62,8 @@ private:
 	uint32_t									mtry;
 	uint32_t									seed;
 	uint32_t									verboseLevel;
+	uint32_t									trainingAuroc;
+	uint32_t									trainingAuprc;
 	std::string									outfilename;
 	std::string									timeFilename;
 	std::string									forestDirname;


### PR DESCRIPTION
includes cmath and closes  #7

further `trainingAuroc` and `trainingAuprc` are not defined. I use `uint32_t` for that. hopefully it is correct. maybe `double`?